### PR TITLE
Use string hash for comparing strings

### DIFF
--- a/test/test-custom.4th
+++ b/test/test-custom.4th
@@ -1,0 +1,35 @@
+\ Copyright 2019 nomennescio
+
+s" custom messages" describe#{
+
+  :noname ." Just passed" cr ; ^passed !
+  :noname ." Just failed" cr ; ^different !
+
+  s" short strings" it#{
+    <{ s" Hello World!" s# -> s" Hello World!" s# }>
+    <{ s" Hello Worlds!" s# -> s" Hello Worlds!" s# }>
+  }#
+  s" failing compares" it#{
+    <{ s" Hello World!" s# -> s" Hello Worlds!" s# }>
+    <{ s" Hello Worlds!" s# -> s" Hello Worlds! " s# }>
+  }#
+
+  2variable actual$
+  2variable expected$
+
+  :noname ." Got '" actual$ 2@ type ." ' as expected" cr ; ^passed !
+  :noname ." Expected '" expected$ 2@ type ." ', got '" actual$ 2@ type ." '" cr ; ^different !
+
+  : &actual 2dup actual$ 2! ;
+  : &expected 2dup expected$ 2! ;
+
+  s" short strings" it#{
+    <{ s" Hello World!" &actual s# -> s" Hello World!" &expected s# }>
+    <{ s" Hello Worlds!" &actual s# -> s" Hello Worlds!" &expected s# }>
+  }#
+  s" failing compares" it#{
+    <{ s" Hello World!" &actual s# -> s" Hello Worlds!" &expected s# }>
+    <{ s" Hello Worlds!" &actual s# -> s" Hello Worlds! " &expected s# }>
+  }#
+
+}#

--- a/test/test-custom.expected
+++ b/test/test-custom.expected
@@ -1,0 +1,36 @@
+
+<DESCRIBE::>custom messages
+
+<IT::>short strings
+
+<PASSED::>Just passed
+
+<PASSED::>Just passed
+
+<COMPLETEDIN::>0.139 ms
+
+<IT::>failing compares
+
+<FAILED::>Just failed
+
+<FAILED::>Just failed
+
+<COMPLETEDIN::>0.162 ms
+
+<IT::>short strings
+
+<PASSED::>Got 'Hello World!' as expected
+
+<PASSED::>Got 'Hello Worlds!' as expected
+
+<COMPLETEDIN::>0.149 ms
+
+<IT::>failing compares
+
+<FAILED::>Expected 'Hello Worlds!', got 'Hello World!'
+
+<FAILED::>Expected 'Hello Worlds! ', got 'Hello Worlds!'
+
+<COMPLETEDIN::>0.150 ms
+
+<COMPLETEDIN::>1.365 ms

--- a/test/test-hash.4th
+++ b/test/test-hash.4th
@@ -8,4 +8,8 @@ s" string hash" describe#{
     <{ s" Hello World!" s# -> s" Hello Worlds!" s# }>
     <{ s" Hello Worlds!" s# -> s" Hello Worlds! " s# }>
   }#
+  s" failing compares with custom messages" it#{
+    <{ s" Hello World!" 2dup ." Actual: '" type ." '" s# -> s" Hello Worlds!" 2dup ." , Expected: '" type ." '" s# }>
+    <{ s" Hello Worlds!" 2dup ." Actual: '" type ." '" s# -> s" Hello Worlds! " 2dup ." , Expected: '" type ." '" s# }>
+  }#
 }#

--- a/test/test-hash.4th
+++ b/test/test-hash.4th
@@ -8,8 +8,4 @@ s" string hash" describe#{
     <{ s" Hello World!" s# -> s" Hello Worlds!" s# }>
     <{ s" Hello Worlds!" s# -> s" Hello Worlds! " s# }>
   }#
-  s" failing compares with custom messages" it#{
-    <{ s" Hello World!" 2dup ." Actual: '" type ." '" s# -> s" Hello Worlds!" 2dup ." , Expected: '" type ." '" s# }>
-    <{ s" Hello Worlds!" 2dup ." Actual: '" type ." '" s# -> s" Hello Worlds! " 2dup ." , Expected: '" type ." '" s# }>
-  }#
 }#

--- a/test/test-hash.4th
+++ b/test/test-hash.4th
@@ -1,0 +1,11 @@
+\ Copyright 2019 nomennescio
+s" string hash" describe#{
+  s" short strings" it#{
+    <{ s" Hello World!" s# -> s" Hello World!" s# }>
+    <{ s" Hello Worlds!" s# -> s" Hello Worlds!" s# }>
+  }#
+  s" failing compares" it#{
+    <{ s" Hello World!" s# -> s" Hello Worlds!" s# }>
+    <{ s" Hello Worlds!" s# -> s" Hello Worlds! " s# }>
+  }#
+}#

--- a/test/test-hash.expected
+++ b/test/test-hash.expected
@@ -1,0 +1,20 @@
+
+<DESCRIBE::>string hash
+
+<IT::>short strings
+
+<PASSED::>Test Passed
+
+<PASSED::>Test Passed
+
+<COMPLETEDIN::>0.098 ms
+
+<IT::>failing compares
+
+<FAILED::>Expected 431880812 , got 390772129 
+
+<FAILED::>Expected 143064460 , got 431880812 
+
+<COMPLETEDIN::>0.118 ms
+
+<COMPLETEDIN::>0.258 ms

--- a/test/test-hash.expected
+++ b/test/test-hash.expected
@@ -7,22 +7,22 @@
 
 <PASSED::>Test Passed
 
-<COMPLETEDIN::>0.077 ms
+<COMPLETEDIN::>0.081 ms
 
 <IT::>failing compares
 
-<FAILED::>Expected 431880812 , got 390772129 
+<FAILED::>Expected 1138466699 , got 297433350 
 
-<FAILED::>Expected 143064460 , got 431880812 
+<FAILED::>Expected 1662069178 , got 1138466699 
 
-<COMPLETEDIN::>0.093 ms
+<COMPLETEDIN::>0.118 ms
 
 <IT::>failing compares with custom messages
 Actual: 'Hello World!', Expected: 'Hello Worlds!'
-<FAILED::>Expected 431880812 , got 390772129 
+<FAILED::>Expected 1138466699 , got 297433350 
 Actual: 'Hello Worlds!', Expected: 'Hello Worlds! '
-<FAILED::>Expected 143064460 , got 431880812 
+<FAILED::>Expected 1662069178 , got 1138466699 
 
-<COMPLETEDIN::>0.167 ms
+<COMPLETEDIN::>0.151 ms
 
-<COMPLETEDIN::>0.386 ms
+<COMPLETEDIN::>0.397 ms

--- a/test/test-hash.expected
+++ b/test/test-hash.expected
@@ -7,7 +7,7 @@
 
 <PASSED::>Test Passed
 
-<COMPLETEDIN::>0.098 ms
+<COMPLETEDIN::>0.077 ms
 
 <IT::>failing compares
 
@@ -15,6 +15,14 @@
 
 <FAILED::>Expected 143064460 , got 431880812 
 
-<COMPLETEDIN::>0.118 ms
+<COMPLETEDIN::>0.093 ms
 
-<COMPLETEDIN::>0.258 ms
+<IT::>failing compares with custom messages
+Actual: 'Hello World!', Expected: 'Hello Worlds!'
+<FAILED::>Expected 431880812 , got 390772129 
+Actual: 'Hello Worlds!', Expected: 'Hello Worlds! '
+<FAILED::>Expected 143064460 , got 431880812 
+
+<COMPLETEDIN::>0.167 ms
+
+<COMPLETEDIN::>0.386 ms

--- a/test/test-hash.expected
+++ b/test/test-hash.expected
@@ -7,22 +7,22 @@
 
 <PASSED::>Test Passed
 
-<COMPLETEDIN::>0.081 ms
+<COMPLETEDIN::>0.211 ms
 
 <IT::>failing compares
 
-<FAILED::>Expected 1138466699 , got 297433350 
+<FAILED::>Expected 1266463317 , got 610024131 
 
-<FAILED::>Expected 1662069178 , got 1138466699 
+<FAILED::>Expected 1589968543 , got 1266463317 
 
-<COMPLETEDIN::>0.118 ms
+<COMPLETEDIN::>0.206 ms
 
 <IT::>failing compares with custom messages
 Actual: 'Hello World!', Expected: 'Hello Worlds!'
-<FAILED::>Expected 1138466699 , got 297433350 
+<FAILED::>Expected 1266463317 , got 610024131 
 Actual: 'Hello Worlds!', Expected: 'Hello Worlds! '
-<FAILED::>Expected 1662069178 , got 1138466699 
+<FAILED::>Expected 1589968543 , got 1266463317 
 
-<COMPLETEDIN::>0.151 ms
+<COMPLETEDIN::>0.344 ms
 
-<COMPLETEDIN::>0.397 ms
+<COMPLETEDIN::>0.864 ms

--- a/test/test-hash.expected
+++ b/test/test-hash.expected
@@ -7,7 +7,7 @@
 
 <PASSED::>Test Passed
 
-<COMPLETEDIN::>0.211 ms
+<COMPLETEDIN::>0.125 ms
 
 <IT::>failing compares
 
@@ -15,14 +15,6 @@
 
 <FAILED::>Expected 1589968543 , got 1266463317 
 
-<COMPLETEDIN::>0.206 ms
+<COMPLETEDIN::>0.124 ms
 
-<IT::>failing compares with custom messages
-Actual: 'Hello World!', Expected: 'Hello Worlds!'
-<FAILED::>Expected 1266463317 , got 610024131 
-Actual: 'Hello Worlds!', Expected: 'Hello Worlds! '
-<FAILED::>Expected 1589968543 , got 1266463317 
-
-<COMPLETEDIN::>0.344 ms
-
-<COMPLETEDIN::>0.864 ms
+<COMPLETEDIN::>0.292 ms

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -39,4 +39,7 @@ variable DIFFERENCES
   EMPTY-STACK
   F} ;
 
-: s# { c-addr u -- hash } 1000000009 { m } 0 1 c-addr u 0 +do { hash p s } s c@ p * hash + m mod p 53 * m mod s char+ loop 2drop ;
+1000000009 constant #m \ prime number < 2^32
+53 constant #p         \ prime number
+: c# { hash pow c -- hash' pow' } c pow * hash + #m mod pow #p * #m mod ;       \ polynomial rolling hash function, single char
+: s# { c-addr u -- hash } 0 1 c-addr u 0 +do { s } s c@ c# s char+ loop 2drop ; \ string hash

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -38,3 +38,5 @@ variable DIFFERENCES
   then
   EMPTY-STACK
   F} ;
+
+: s# { c-addr u -- hash } 1000000009 { m } 0 1 c-addr u 0 +do { hash p s } s c@ p * hash + m mod p 53 * m mod s char+ loop 2drop ;

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -39,7 +39,7 @@ variable DIFFERENCES
   EMPTY-STACK
   F} ;
 
-2147483659 constant #m \ prime number < 2^32
+3037000493 constant #m \ prime number < sqrt (2^63-1)
 53 constant #p         \ prime number
 : c# { hash pow c -- hash' pow' } c pow * hash + #m mod pow #p * #m mod ;       \ polynomial rolling hash function, single char
 : s# { c-addr u -- hash } 0 1 c-addr u 0 +do { s } s c@ c# s char+ loop 2drop ; \ string hash

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -15,26 +15,39 @@ create EXPECTED-RESULTS 32 cells allot
 variable RESULTS
 variable DIFFERENCES
 
+variable ^passed
+variable ^nresults
+variable ^different
+
+: passed$  ." Test Passed" cr ;
+: different$ ." Expected "
+  RESULTS @ 0 +do EXPECTED-RESULTS i cells + @ . loop
+  ." , got "
+  RESULTS @ 0 +do ACTUAL-RESULTS i cells + @ . loop
+  cr ;
+: nresults$ ." Wrong number of results, expected " depth START-DEPTH @ - .
+  ." , got " ACTUAL-DEPTH @ START-DEPTH @ - . cr ;
+
+' passed$ ^passed !
+' nresults$ ^nresults !
+' different$ ^different !
+
 : <{ T{ ;
 : }>
   depth ACTUAL-DEPTH @ = if
     depth START-DEPTH @ > if
-      depth START-DEPTH @ - dup RESULTS ! 0 do
+      depth START-DEPTH @ - dup RESULTS ! 0 +do
         dup EXPECTED-RESULTS i cells + !
         ACTUAL-RESULTS i cells + @ <> DIFFERENCES +!
       loop
       DIFFERENCES @ if
-        failed# ." Expected "
-        RESULTS @ 0 do EXPECTED-RESULTS i cells + @ . loop
-        ." , got "
-        RESULTS @ 0 do ACTUAL-RESULTS i cells + @ . loop
-        cr
+        failed# ^different @ execute
       else
-        passed# ." Test Passed" cr
+        passed# ^passed @ execute
       then
     then
   else
-    failed# ." Wrong number of results, expected " depth START-DEPTH @ - . ." , got " ACTUAL-DEPTH @ START-DEPTH @ - . cr
+    failed# ^nresults @ execute
   then
   EMPTY-STACK
   F} ;

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -36,6 +36,7 @@ variable ^different
 : }>
   depth ACTUAL-DEPTH @ = if
     depth START-DEPTH @ > if
+      0 DIFFERENCES !
       depth START-DEPTH @ - dup RESULTS ! 0 +do
         dup EXPECTED-RESULTS i cells + !
         ACTUAL-RESULTS i cells + @ <> DIFFERENCES +!

--- a/ttester-codewars.4th
+++ b/ttester-codewars.4th
@@ -39,7 +39,7 @@ variable DIFFERENCES
   EMPTY-STACK
   F} ;
 
-1000000009 constant #m \ prime number < 2^32
+2147483659 constant #m \ prime number < 2^32
 53 constant #p         \ prime number
 : c# { hash pow c -- hash' pow' } c pow * hash + #m mod pow #p * #m mod ;       \ polynomial rolling hash function, single char
 : s# { c-addr u -- hash } 0 1 c-addr u 0 +do { s } s c@ c# s char+ loop 2drop ; \ string hash


### PR DESCRIPTION
The current test framework can test equality on cells on the datastack. To add string support to the testing framework, a word 's#' has been added to hash a string into a cell. Test code and expected output has been added. Reporting on string mismatch will however show a mismatch on hash value, which is not very informative to the user. I think the benefit of being able to test string equality currently outweighs that disadvantage.